### PR TITLE
Add .env-override file to Docker build commands

### DIFF
--- a/ngencerf/start-template-v3.sh
+++ b/ngencerf/start-template-v3.sh
@@ -327,7 +327,7 @@ chmod a+w ${service_ngencerf_ui_dir}/production-pw.yaml
 #container_name="ngencerf-ui-ngencerf-app-${service_port}"
 #echo "sudo docker stop ${container_name}" >> cancel.sh
 echo "cd ${service_ngencerf_docker_dir}" >> cancel.sh
-echo "docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml down --remove-orphans" >> cancel.sh
+echo "docker compose --env-file /ngencerf-app/ngencerf-server/docker.env --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override -f production-pw.yaml down --remove-orphans" >> cancel.sh
 
 cd ${service_ngencerf_docker_dir}
 
@@ -351,26 +351,46 @@ fi
 
 if [[ "${service_build}" == "true" ]]; then
   # build locally and start ngencerf-server
-  CACHE_BUST=$(date +%s) docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml up -d --build ngencerf-services
+  CACHE_BUST=$(date +%s) docker compose \
+    --env-file /ngencerf-app/ngencerf-server/docker.env \
+    --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+    -f production-pw.yaml up -d --build ngencerf-services
 
   # build locally and start ngencerf-ui
-  docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml up -d --build --no-deps ngencerf-ui
+  docker compose \
+    --env-file /ngencerf-app/ngencerf-server/docker.env \
+    --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+    -f production-pw.yaml up -d --build --no-deps ngencerf-ui
 
 else
   # pull ngencerf-server from registry
-  CACHE_BUST=$(date +%s) docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml pull ngencerf-services
+  CACHE_BUST=$(date +%s) docker compose \
+    --env-file /ngencerf-app/ngencerf-server/docker.env \
+    --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+    -f production-pw.yaml pull ngencerf-services
 
 
   # start ngencerf-server
-  CACHE_BUST=$(date +%s) docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml up -d --no-build ngencerf-services
+  CACHE_BUST=$(date +%s) docker compose \
+    --env-file /ngencerf-app/ngencerf-server/docker.env \
+    --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+    -f production-pw.yaml up -d --no-build ngencerf-services
 
 
   # build locally and start ngencerf-ui
   # TODO: pull from registry
-  docker compose -f production-pw.yaml up --env-file /ngencerf-app/ngencerf-server/docker.env -d --build --no-deps ngencerf-ui
+  docker compose \
+    --env-file /ngencerf-app/ngencerf-server/docker.env \
+    --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+    -f production-pw.yaml up -d --build --no-deps ngencerf-ui
 fi
 
-ngencerf_image="$(docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml config | awk '/ngencerf-server/{flag=1} flag && /image:/{print $2; exit}')"
+ngencerf_image="$(docker compose \
+  --env-file /ngencerf-app/ngencerf-server/docker.env \
+  --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+  -f production-pw.yaml \
+  config | awk '/ngencerf-server/{flag=1} flag && /image:/{print $2; exit}')"
+
 echo "ngencerf_image=${ngencerf_image}"
 
 # clean any previous temp container quietly
@@ -387,7 +407,10 @@ else
 fi
 
 # Tail the logs
-docker compose --env-file /ngencerf-app/ngencerf-server/docker.env -f production-pw.yaml logs -f
-
+docker compose \
+  --env-file /ngencerf-app/ngencerf-server/docker.env \
+  --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+  -f production-pw.yaml \
+  logs -f
 
 sleep infinity

--- a/ngencerf/start-template-v3.sh
+++ b/ngencerf/start-template-v3.sh
@@ -363,13 +363,6 @@ if [[ "${service_build}" == "true" ]]; then
     -f production-pw.yaml up -d --build --no-deps ngencerf-ui
 
 else
-  # pull ngencerf-server from registry
-  CACHE_BUST=$(date +%s) docker compose \
-    --env-file /ngencerf-app/ngencerf-server/docker.env \
-    --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-    -f production-pw.yaml pull ngencerf-services
-
-
   # start ngencerf-server
   CACHE_BUST=$(date +%s) docker compose \
     --env-file /ngencerf-app/ngencerf-server/docker.env \
@@ -378,11 +371,10 @@ else
 
 
   # build locally and start ngencerf-ui
-  # TODO: pull from registry
   docker compose \
     --env-file /ngencerf-app/ngencerf-server/docker.env \
     --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-    -f production-pw.yaml up -d --build --no-deps ngencerf-ui
+    -f production-pw.yaml up -d --no-build --no-deps ngencerf-ui
 fi
 
 ngencerf_image="$(docker compose \

--- a/ngencerf/start-template-v3.sh
+++ b/ngencerf/start-template-v3.sh
@@ -327,7 +327,11 @@ chmod a+w ${service_ngencerf_ui_dir}/production-pw.yaml
 #container_name="ngencerf-ui-ngencerf-app-${service_port}"
 #echo "sudo docker stop ${container_name}" >> cancel.sh
 echo "cd ${service_ngencerf_docker_dir}" >> cancel.sh
-echo "docker compose --env-file /ngencerf-app/ngencerf-server/docker.env --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override -f production-pw.yaml down --remove-orphans" >> cancel.sh
+echo "docker compose \
+  --env-file /ngencerf-app/ngencerf-server/docker.env \
+  --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
+  --file production-pw.yaml \
+  down --remove-orphans" >> cancel.sh
 
 cd ${service_ngencerf_docker_dir}
 
@@ -354,33 +358,32 @@ if [[ "${service_build}" == "true" ]]; then
   CACHE_BUST=$(date +%s) docker compose \
     --env-file /ngencerf-app/ngencerf-server/docker.env \
     --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-    -f production-pw.yaml up -d --build ngencerf-services
+    --file production-pw.yaml up --detach --build ngencerf-services
 
   # build locally and start ngencerf-ui
   docker compose \
     --env-file /ngencerf-app/ngencerf-server/docker.env \
     --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-    -f production-pw.yaml up -d --build --no-deps ngencerf-ui
+    --file production-pw.yaml up --detach --build --no-deps ngencerf-ui
 
 else
   # start ngencerf-server
   CACHE_BUST=$(date +%s) docker compose \
     --env-file /ngencerf-app/ngencerf-server/docker.env \
     --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-    -f production-pw.yaml up -d --no-build ngencerf-services
-
+    --file production-pw.yaml up --detach --no-build --pull never ngencerf-services
 
   # build locally and start ngencerf-ui
   docker compose \
     --env-file /ngencerf-app/ngencerf-server/docker.env \
     --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-    -f production-pw.yaml up -d --no-build --no-deps ngencerf-ui
+    --file production-pw.yaml up --detach --no-build --pull never --no-deps ngencerf-ui
 fi
 
 ngencerf_image="$(docker compose \
   --env-file /ngencerf-app/ngencerf-server/docker.env \
   --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-  -f production-pw.yaml \
+  --file production-pw.yaml \
   config | awk '/ngencerf-server/{flag=1} flag && /image:/{print $2; exit}')"
 
 echo "ngencerf_image=${ngencerf_image}"
@@ -402,7 +405,7 @@ fi
 docker compose \
   --env-file /ngencerf-app/ngencerf-server/docker.env \
   --env-file /ngencerf-app/ngencerf-server/cerfServer/.env-override \
-  -f production-pw.yaml \
+  --file production-pw.yaml \
   logs -f
 
 sleep infinity


### PR DESCRIPTION
- added `.env-override` to docker commands to load variables in file during build time
- made changes to allow the option of bringing up ngencerf-server and ngencerf-ui containers without building them by setting "Build Docker Containers?" to "No" when starting PW workflow. 